### PR TITLE
Fix for patch kexts stage failing to find install media due of unquoted strings passed to bash

### DIFF
--- a/Patched Sur/Actions/PatchKextsActions.swift
+++ b/Patched Sur/Actions/PatchKextsActions.swift
@@ -15,13 +15,13 @@ func detectPatches(installerName: (String?) -> (), legacy: (Bool) -> ()) {
     print("Checking for USB at \"/Volumes/Install macOS Big Sur Beta/KextPatches\"...")
     if (try? call("[[ -d '/Volumes/Install macOS Big Sur Beta/KextPatches' ]]")) != nil {
         print("Found PSPatches at Beta path")
-        installerName("/Volumes/Install macOS Big Sur Beta")
+        installerName("'/Volumes/Install macOS Big Sur Beta'")
         return
     }
     print("Checking for USB at \"/Volumes/Install macOS Big Sur/KextPatches\"")
     if (try? call("[[ -d '/Volumes/Install macOS Big Sur/KextPatches' ]]")) != nil {
         print("Found PSPatches at Regular path")
-        installerName("/Volumes/Install macOS Big Sur")
+        installerName("'/Volumes/Install macOS Big Sur'")
         return
     }
     print("Checking for kexts at \"/usr/local/lib/Patched-Sur-Patches/KextPatches")
@@ -37,7 +37,7 @@ func detectPatches(installerName: (String?) -> (), legacy: (Bool) -> ()) {
     if (try? call("[[ -d '/Volumes/Install macOS Big Sur Beta/kexts' ]]")) != nil {
         print("Found micropatcher at legacy Beta path")
         print("It is! This will be used even though it is the last resort.")
-        installerName("/Volumes/Install macOS Big Sur Beta")
+        installerName("'/Volumes/Install macOS Big Sur Beta'")
         legacy(true)
         return
     }
@@ -45,7 +45,7 @@ func detectPatches(installerName: (String?) -> (), legacy: (Bool) -> ()) {
     if (try? call("[[ -d '/Volumes/Install macOS Big Sur/kexts' ]]")) != nil {
         print("Found micropatcher at legacy regular path")
         print("It is! This will be used even though it is the last resort.")
-        installerName("/Volumes/Install macOS Big Sur")
+        installerName("'/Volumes/Install macOS Big Sur'")
         legacy(true)
         return
     }


### PR DESCRIPTION
The Patch Kexts stage was failing due of spaces being passed into bash not being in quotes.

```
thunderysteak@Thunderys-Mac-mini ~ % sudo /Applications/Patched\ Sur.app/Contents/MacOS/Patched\ Sur
Hello! If you're seeing this, you are seeing the logs of Patched Sur!
Or maybe running this from the command line...

Patched Sur v0.2.0 Build 89
Running Either Normally or From Terminal in RELEASE configuration.

Checking if we want to fix v0.1.0 deprecated values...
Checking if we want to fix v0.2.0 deprecated values...
Unknown option (/Applications/Patched Sur.app/Contents/MacOS/Patched Sur) detected. Ignoring option. (Use --help to see available options)
nvram: Error getting variable - '4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:oem-product': (iokit/common) data was not found
Macmini6,1
Detected Mac Model: Macmini6,1
BuildVersion:	20D91
Detected macOS Build Number: 20D91
Detected Release Track: Release
Loading Main Screen...

Checking for USB at "/Volumes/Install macOS Big Sur Beta/KextPatches"...
Checking for USB at "/Volumes/Install macOS Big Sur/KextPatches"
Found PSPatches at Regular path
Correct Password
Starting Patch Kexts
sudo: /Volumes/Install: command not found
Checking for USB at "/Volumes/Install macOS Big Sur Beta/KextPatches"...
Checking for USB at "/Volumes/Install macOS Big Sur/KextPatches"
Found PSPatches at Regular path
Correct Password
Starting Patch Kexts
sudo: /Volumes/Install: command not found
```

By adding quotes the patching works normally

```
Hello! If you're seeing this, you are seeing the logs of Patched Sur!
Or maybe running this from the command line...

Patched Sur v0.2.0 Build 89
Running From Xcode in DEBUG configuration.

Checking if we want to fix v0.1.0 deprecated values...
Checking if we want to fix v0.2.0 deprecated values...
Unknown option (/Users/thunderysteak/Library/Developer/Xcode/DerivedData/Patched_Sur-ehaywleiajkqiaffsshutriwvrda/Build/Products/Debug/Patched Sur.app/Contents/MacOS/Patched Sur) detected. Ignoring option. (Use --help to see available options)
Detected --allow-reinstall option, reinstalls enabled.
Unknown option (-NSDocumentRevisionsDebugMode) detected. Ignoring option. (Use --help to see available options)
Unknown option (YES) detected. Ignoring option. (Use --help to see available options)
nvram: 
Error getting variable - '4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:oem-product': (iokit/common) data was not found
Macmini6,1
Detected Mac Model: Macmini6,1
BuildVersion:	20D91
Detected macOS Build Number: 20D91
Detected Release Track: Release
Loading Main Screen...

Checking for USB at "/Volumes/Install macOS Big Sur Beta/KextPatches"...
Checking for USB at "/Volumes/Install macOS Big Sur/KextPatches"
Found PSPatches at Regular path
2021-04-25 05:18:23.431737+0100 Patched Sur[2956:50803] Metal API Validation Enabled
Sorry, try again.

sudo: no password was provided
sudo: 1 incorrect password attempt

Correct Password
Starting Patch Kexts

Welcome to PatchKexts.sh (for Patched Sur)!

Checking environment...
We're booted into full macOS.
Confirming patch location...
Patch Location: /Volumes/Install macOS Big Sur
Checking WiFi patch configuration...
```