### PR TITLE
Patched sur uses custom icons from the drives such as efi and install MacOs, so the documentation was old, so its updated now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To see if your Mac is supported [click here](https://bensova.gitbook.io/big-sur/
 
 To choose a different installer that you already have downloaded, click `View Other Versions`. Then, click `Find an Installer` and navigate to the InstallAssistant.pkg or Install macOS Big Sur.app file you would like to use.
 
-#### How would I update macOS? (Stating in 0.10+)
+#### How would I update macOS? (Starting in 0.10+)
 
 To update macOS, follow the steps below.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To see if your Mac is supported [click here](https://bensova.gitbook.io/big-sur/
 
 **10.** Reboot your computer, but immediately start holding down the `Option/Alt` key as soon as your Mac turns on.
 
-**11.** Select the __yellow__ EFI Boot drive, (if there are multiple unplug and replug in your drive and select the EFI Boot that disappeared and reappeared).  Then, your Mac will quickly turn off, so turn it back on while, again, holding down `Option/Alt`. Then, select Install macOS Big Sur.
+**11.** Select the __Purple__ EFI Boot drive or logo, (if there are multiple unplug and replug in your drive and select the EFI Boot that disappeared and reappeared).  Then, your Mac will quickly turn off, so turn it back on while, again, holding down `Option/Alt`. Then, select Install macOS Big Sur which should be a green drive/logo.
 
 **12.** Once the installer boots, select reinstall macOS and agree to the Terms and Conditions. Then, select the drive you want to install Big Sur onto, (it should be the same drive you ran the patcher on).
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ To update macOS, follow the steps below.
 
 **5.** Enjoy the latest version of macOS!
 
-Note: Apple does not always release InstallAssistant.pkgs for the beta tracks, this means you might be unable to get certian betas.
+Note: Apple does not always release InstallAssistant.pkgs for the beta tracks and some minor updates, this means you might be unable to get certian upates.
 
 ## Support
+
+I am a living, breathing human, so don't expect me to respond right away to everything. However, if you need support with the patcher, feel free to open an issue or discussion here (please search the issue list before making a new one) or use one of the links below!
+
 [r/BigSurPatcher Subreddit](https://www.reddit.com/r/BigSurPatcher/)
+
 [Unsupported Macs Discord](https://discord.com/invite/XbbWAsE) (#bensova-patcher)


### PR DESCRIPTION
The EFI and install macOS drives were never updated in the read me for the change to custom icons and to purple and green colored icons, so they are now.