### PR TITLE
fix confusing and nonsensical wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Patched Sur is a UI patcher for macOS Big Sur, designed to make it easy to run m
 ## Compatibility
 To see if your Mac is supported [click here](https://bensova.gitbook.io/big-sur/supported-macs).
 
-(Basically it says if you have a 2012/2013 Mac it'll be terrible but anything else is better).
+(Basically it says if you have anything older than a 2012/2013 Mac it'll be terrible).
 
 ## Credits
 


### PR DESCRIPTION
the whole sentence is incorrect and doesn't reflect the state of big sur on these older macs. users of macs older than 2012 may read this sentence and blindly assume they'll have the superior experience, and 2012 and 2013 mac users may assume the opposite. 2012 and 2013 macs run the best with the patched operating system, not the other way around.